### PR TITLE
No pylab for example scripts

### DIFF
--- a/potassium41.py
+++ b/potassium41.py
@@ -1,6 +1,6 @@
 from __future__ import division
-from pylab import *
-
+from numpy import pi, linspace
+from matplotlib.pyplot import plot, grid, xlabel, ylabel, legend, show
 from .atom import AtomicState, AtomicLine, FineStructureLine, hbar, c, epsilon_0, e, d_B
        
 # 41K D line properties:

--- a/rubidium85.py
+++ b/rubidium85.py
@@ -1,6 +1,6 @@
 from __future__ import division
-from pylab import *
-
+from numpy import pi, linspace
+from matplotlib.pyplot import plot, grid, xlabel, ylabel, legend, show
 from .atom import AtomicState, AtomicLine, FineStructureLine, hbar, c, epsilon_0, e, d_B
        
 # 85Rb D line properties

--- a/rubidium87.py
+++ b/rubidium87.py
@@ -1,6 +1,6 @@
 from __future__ import division
-from pylab import *
-
+from numpy import pi, linspace
+from matplotlib.pyplot import plot, grid, xlabel, ylabel, legend, show
 from .atom import AtomicState, AtomicLine, FineStructureLine, hbar, c, epsilon_0, e, d_B
        
 # 87Rb D line properties


### PR DESCRIPTION
Remove pylab import lines on all atom example scripts and replace with suitable numpy and matplotlib imports.